### PR TITLE
0.0.56

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 
     //versions & naming
-    ext.csenseVersionName = "0.0.55"
+    ext.csenseVersionName = "0.0.56"
     ext.csenseGroupId = "csense.kotlin"
     ext.csenseArtifactId = "csense-kotlin-tests"
 
@@ -54,7 +54,15 @@ version project.csenseVersionName
 
 kotlin {
     explicitApi = 'strict'
-    jvm()
+    jvm {
+        compilations.all {
+            kotlinOptions.jvmTarget = '1.8'
+        }
+        withJava()
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
     js(BOTH) { //https://kotlinlang.org/docs/reference/whatsnew14.html#new-js-ir-backend
         browser()
         nodejs()
@@ -98,21 +106,5 @@ kotlin {
 project.group = csenseGroupId
 project.version = csenseVersionName
 
-
-jvmTest {
-    testLogging {
-        showStandardStreams = true
-        events "skipped", "failed", "standardOut", "standardError"
-        exceptionFormat "full"
-        showCauses true
-        showExceptions true
-        showStackTraces true
-    }
-    useJUnitPlatform()
-    reports {
-        junitXml.enabled = true
-        html.enabled = true
-    }
-}
 
 apply from: "$rootDir/gradle/publish.gradle"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
   - assertContains on iterable
 - updated 
   - assertByEquals so it requires the same type for both actual & expected (before it would generically default to any)
+- deprecated
+  - number.assert
 
 # 0.0.55
 - added assertByEquals

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # 0.0.56
 - added
   - assertContains on iterable
+- updated 
+  - assertByEquals so it requires the same type for both actual & expected (before it would generically default to any)
 
 # 0.0.55
 - added assertByEquals

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.0.56
+- added
+  - assertContains on iterable
+
 # 0.0.55
 - added assertByEquals
 

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
@@ -218,7 +218,7 @@ public inline fun <reified T> assertCallbackCalledWith(
 /**
  * Asserts that this is equal to expected
  */
-public inline fun <T> T.assertByEquals(
+public inline fun <@kotlin.internal.OnlyInputTypes T> T.assertByEquals(
     expected: T?,
     optMessage: String? = null
 ) {

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Iterable.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Iterable.kt
@@ -53,3 +53,13 @@ public inline fun <@kotlin.internal.OnlyInputTypes T> Iterable<T>.assertContains
     }
     failTest("Could not find `$currentItem`, last successful found item was at index $lastFoundMessage, which is `$lastFoundElement`")
 }
+
+public inline fun <E> Iterable<E>.assertContains(
+    message: String = "",
+    predicate: (item: E) -> Boolean
+) {
+    val foundAny = any {
+        predicate(it)
+    }
+    foundAny.assertTrue("Wanted to find a item matching the given predicate, but found none.$message")
+}

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Number.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Number.kt
@@ -152,6 +152,10 @@ public inline fun IntRange.assertNot(
 
 
 @kotlin.internal.LowPriorityInOverloadResolution
+@Deprecated(
+    message = "This causes problems thus it is best to avoid it. Will be removed in a future release",
+    level = DeprecationLevel.WARNING
+)
 public inline fun Number?.assert(expected: Number) {
     if (this == null) {
         fail("expected $expected but got $this")


### PR DESCRIPTION
- added
  - assertContains on iterable
- updated 
  - assertByEquals so it requires the same type for both actual & expected (before it would generically default to any)
- deprecated
  - number.assert