### PR TITLE
0.0.59

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 
     //versions & naming
-    ext.csenseVersionName = "0.0.59-snapshot"
+    ext.csenseVersionName = "0.0.59"
     ext.csenseGroupId = "csense.kotlin"
     ext.csenseArtifactId = "csense-kotlin-tests"
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
                 implementation kotlin('test-common')
                 implementation kotlin('test-annotations-common')
                 implementation "csense.kotlin:csense-kotlin-annotations:$csenseAnnotationVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 
     //versions & naming
-    ext.csenseVersionName = "0.0.58"
+    ext.csenseVersionName = "0.0.59-snapshot"
     ext.csenseGroupId = "csense.kotlin"
     ext.csenseArtifactId = "csense-kotlin-tests"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     //dependencies
     //https://github.com/Kotlin/kotlinx.coroutines
-    ext.coroutinesVersion = "1.6.3"
+    ext.coroutinesVersion = "1.6.4"
     //https://github.com/junit-team/junit5/releases
-    ext.junit5Version = "5.8.2"
+    ext.junit5Version = "5.9.1"
     //https://github.com/junit-team/junit4/releases
     ext.junit4Version = "4.13.2"
     //https://github.com/JetBrains/kotlin/releases
-    ext.kotlin_version = "1.7.0"
+    ext.kotlin_version = "1.7.20"
     //https://github.com/csense-oss/csense-kotlin-annotations
     ext.csenseAnnotationVersion = "0.0.50"
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.0.59
+- added
+  - (T & Any).nullable (to assist if say there are deprecated overloads for functions that disallow nonnull able types)
+
+- improved Array.assert (with "out variance")
+
 # 0.0.58
 - added 
   - Array<T>.assert

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # 0.0.59
 - added
   - (T & Any).nullable (to assist if say there are deprecated overloads for functions that disallow nonnull able types)
+  - TestScope.advanceTimeBy(duration: Duration)
 
 - improved Array.assert (with "out variance")
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,6 @@
       types)
     - TestScope.advanceTimeBy(duration: Duration)
     - Map.Entry.assertByEquals
-    - 
 
 - improved Array.assert (with "out variance")
 - renamed Pair.assert to Pair.assertByEquals

--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,25 @@
 # 0.0.59
+
+- using kotlin 1.7.20
 - added
-  - (T & Any).nullable (to assist if say there are deprecated overloads for functions that disallow nonnull able types)
-  - TestScope.advanceTimeBy(duration: Duration)
+    - (T & Any).nullable (to assist if say there are deprecated overloads for functions that disallow nonnull able
+      types)
+    - TestScope.advanceTimeBy(duration: Duration)
+    - Map.Entry.assertByEquals
+    - 
 
 - improved Array.assert (with "out variance")
+- renamed Pair.assert to Pair.assertByEquals
 
 # 0.0.58
-- added 
-  - Array<T>.assert
-    - and for all specific array types
-  - assertNotEmpty() for all specific array types
+
+- added
+    - Array<T>.assert
+        - and for all specific array types
+    - assertNotEmpty() for all specific array types
 
 # 0.0.57
+
 - kotlin 1.7.0
 - better callback names (makes idea suggest / use meaningful name(s) such as "shouldBeCalled" instead of "callback")
 - better usage of message(s)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Then add the dependency
 
 ```groovy
 dependencies {
-    implementation 'csense.kotlin:csense-kotlin-tests:0.0.58'
+    implementation 'csense.kotlin:csense-kotlin-tests:0.0.59'
 }
 ```
 

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
@@ -374,7 +374,7 @@ public fun FloatArray.assert(
         message = message,
         getSize = FloatArray::size,
         getElementAt = FloatArray::get
-    )
+    )TestScope.advanceTimeBy(duration: Duration)
 }
 
 public fun IntArray.assert(

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
@@ -374,7 +374,7 @@ public fun FloatArray.assert(
         message = message,
         getSize = FloatArray::size,
         getElementAt = FloatArray::get
-    )TestScope.advanceTimeBy(duration: Duration)
+    )
 }
 
 public fun IntArray.assert(

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
@@ -417,16 +417,16 @@ public fun ShortArray.assert(
     )
 }
 
-public fun <T : Comparable<T>> Array<T>.assert(
-    expected: Array<T>,
+public fun <T : Comparable<T>> Array<out T>.assert(
+    expected: Array<out T>,
     message: String = "Expected this Array to be the same as expected but was different"
 ) {
     ArrayAssertions.AssertArrays(
         givenArray = this,
         expected = expected,
         message = message,
-        getSize = Array<T>::size,
-        getElementAt = Array<T>::get
+        getSize = { size },
+        getElementAt = { get(it) }
     )
 }
 

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Arrays.kt
@@ -4,7 +4,6 @@ package csense.kotlin.tests.assertions
 
 import csense.kotlin.annotations.numbers.*
 import kotlin.contracts.*
-import kotlin.math.*
 import kotlin.test.*
 
 //region assertSize

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Bool.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Bool.kt
@@ -1,6 +1,6 @@
 package csense.kotlin.tests.assertions
 
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 /**
  * Asserts this [Boolean] is the given value

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Collections.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Collections.kt
@@ -3,10 +3,8 @@
 package csense.kotlin.tests.assertions
 
 import csense.kotlin.annotations.numbers.*
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
-import kotlin.test.assertEquals
+import kotlin.contracts.*
+import kotlin.test.*
 
 
 /**

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Comparable.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Comparable.kt
@@ -2,9 +2,7 @@
 
 package csense.kotlin.tests.assertions
 
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 /**
  * Asserts the given value is larger or equal to (>=) the asserted value

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
@@ -2,10 +2,8 @@
 
 package csense.kotlin.tests.assertions
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
 
 
 public fun CoroutineScope.assertDispatcher(otherDispatcher: CoroutineDispatcher) {

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
@@ -1,9 +1,12 @@
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 @file:Suppress("unused")
 
 package csense.kotlin.tests.assertions
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
 import kotlin.coroutines.*
+import kotlin.time.*
 
 
 public fun CoroutineScope.assertDispatcher(otherDispatcher: CoroutineDispatcher) {
@@ -14,3 +17,8 @@ private fun CoroutineScope.getCurrentDispatcher() = coroutineContext.getCurrentD
 
 private fun CoroutineContext.getCurrentDispatcher(): CoroutineDispatcher =
     this[ContinuationInterceptor] as CoroutineDispatcher
+
+
+public fun TestScope.advanceTimeBy(duration: Duration) {
+    advanceTimeBy(delayTimeMillis = duration.inWholeMilliseconds)
+}

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
@@ -3,8 +3,7 @@
 package csense.kotlin.tests.assertions
 
 import csense.kotlin.annotations.numbers.*
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
+import kotlin.contracts.*
 import kotlin.test.*
 
 /**

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
@@ -226,8 +226,14 @@ public fun <@kotlin.internal.OnlyInputTypes T> T.assertByEquals(
     )
 }
 
+@Suppress("RedundantNullableReturnType", "NOTHING_TO_INLINE")
+public inline fun <T> (T & Any).nullable(): T? {
+    return this
+}
+
 
 public object GeneralStrings {
     public const val assertCalledMessage: String = "Should be called, but did not get called enough times"
     public const val assertNotCalledMessage: String = "Should not be called but got called anyway"
 }
+

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Map.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Map.kt
@@ -3,10 +3,8 @@
 package csense.kotlin.tests.assertions
 
 import csense.kotlin.annotations.numbers.*
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
-import kotlin.test.assertEquals
+import kotlin.contracts.*
+import kotlin.test.*
 
 /**
  * Assert that this map have the given size.

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/MapEntry.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/MapEntry.kt
@@ -11,3 +11,14 @@ public inline fun <@kotlin.internal.OnlyInputTypes Key, @kotlin.internal.OnlyInp
     this.key.assert(key)
     this.value.assert(value)
 }
+
+
+public inline fun <Key, Value> Map.Entry<Key, Value>?.assertByEquals(
+    key: Key,
+    value: Value
+) {
+    assertNotNull()
+    this.key.assertByEquals(key)
+    this.value.assertByEquals(value)
+}
+

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Number.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Number.kt
@@ -2,7 +2,7 @@
 
 package csense.kotlin.tests.assertions
 
-import kotlin.math.abs
+import kotlin.math.*
 import kotlin.test.*
 
 //region Double

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Pair.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Pair.kt
@@ -1,11 +1,9 @@
 package csense.kotlin.tests.assertions
 
-import kotlin.test.*
-
-public fun <First, Second> Pair<First, Second>?.assert(expected: Pair<First, Second>) {
+public fun <First, Second> Pair<First, Second>?.assertByEquals(expected: Pair<First, Second>) {
     if (this == null) {
         failTest("Expected $expected but got $this")
     }
-    assertEquals(expected.first, this.first)
-    assertEquals(expected.second, this.second)
+    expected.first.assertByEquals(first)
+    expected.second.assertByEquals(second)
 }

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/String.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/String.kt
@@ -2,9 +2,7 @@
 
 package csense.kotlin.tests.assertions
 
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 /**
  * Asserts that this string contains the given value.

--- a/src/commonTest/kotlin/csense/kotlin/tests/assertions/ArraysTest.kt
+++ b/src/commonTest/kotlin/csense/kotlin/tests/assertions/ArraysTest.kt
@@ -1206,7 +1206,7 @@ class ArraysTest {
     }
 
 
-    class ArrayTAssertExpected {
+    class ArrayOutTAssertExpected {
 
         @Test
         fun emptyToEmpty() {

--- a/src/commonTest/kotlin/csense/kotlin/tests/assertions/PairTest.kt
+++ b/src/commonTest/kotlin/csense/kotlin/tests/assertions/PairTest.kt
@@ -8,13 +8,13 @@ class PairTest {
         @Test
         fun nonNullShouldWork() {
             val p1 = Pair("a", "1")
-            p1.assert("a" to "1")
+            p1.assertByEquals("a" to "1")
         }
 
         @Test
         fun nullToNonNullShouldThrow() = assertThrows<Throwable> {
             val p1: Pair<String, String>? = null
-            p1.assert("a" to "1")
+            p1.assertByEquals("a" to "1")
         }
     }
 }


### PR DESCRIPTION
- using kotlin 1.7.20
- added
    - (T & Any).nullable (to assist if say there are deprecated overloads for functions that disallow nonnull able
      types)
    - TestScope.advanceTimeBy(duration: Duration)
    - Map.Entry.assertByEquals

- improved Array.assert (with "out variance")
- renamed Pair.assert to Pair.assertByEquals