### PR TITLE
0.0.60

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-# Gradle
-# Build your Java project and run tests with Gradle using a Gradle wrapper script.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/java
 variables:
   GRADLE_USER_HOME: $(Pipeline.Workspace)/.gradle
 
@@ -31,7 +27,7 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       publishJUnitResults: false
-      tasks: '--build-cache assemble'
+      tasks: 'assemble'
     displayName: Assemble & Test
 
   - task: Gradle@2

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
+
+    ext.compileJavaVersion = "11"
+
+
     //dependencies
     //https://github.com/Kotlin/kotlinx.coroutines
     ext.coroutinesVersion = "1.6.4"
@@ -59,7 +63,7 @@ kotlin {
     explicitApi = ExplicitApiMode.Strict
     jvm {
         compilations.configureEach {
-            kotlinOptions.jvmTarget = '11'
+            kotlinOptions.jvmTarget = compileJavaVersion
         }
         withJava()
         test {
@@ -128,6 +132,13 @@ project.version = csenseVersionName
 
 
 apply from: "$rootDir/gradle/publish.gradle"
+
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(compileJavaVersion))
+    }
+}
 
 
 // warnings as errors

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     //dependencies
     //https://github.com/Kotlin/kotlinx.coroutines
@@ -53,13 +56,13 @@ group project.csenseGroupId
 version project.csenseVersionName
 
 kotlin {
-    explicitApi = 'strict'
+    explicitApi = ExplicitApiMode.Strict
     jvm {
-        compilations.all {
+        compilations.configureEach {
             kotlinOptions.jvmTarget = '11'
         }
         withJava()
-        testRuns["test"].executionTask.configure {
+        test {
             useJUnitPlatform()
         }
     }
@@ -97,12 +100,13 @@ kotlin {
                 api "org.jetbrains.kotlin:kotlin-test-js:$kotlin_version"
             }
         }
-        all {
+        configureEach {
             languageSettings {
-                languageVersion = "1.7"
+                languageVersion = "1.8"
                 optIn("kotlin.contracts.ExperimentalContracts")
                 progressiveMode = true
             }
+
         }
     }
 }
@@ -113,3 +117,11 @@ project.version = csenseVersionName
 
 
 apply from: "$rootDir/gradle/publish.gradle"
+
+
+// warnings as errors
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        kotlinOptions.allWarningsAsErrors = true
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,17 @@ buildscript {
     //https://github.com/Kotlin/kotlinx.coroutines
     ext.coroutinesVersion = "1.6.4"
     //https://github.com/junit-team/junit5/releases
-    ext.junit5Version = "5.9.1"
+    ext.junit5Version = "5.9.2"
     //https://github.com/junit-team/junit4/releases
     ext.junit4Version = "4.13.2"
     //https://github.com/JetBrains/kotlin/releases
-    ext.kotlin_version = "1.7.20"
+    ext.kotlin_version = "1.8.10"
     //https://github.com/csense-oss/csense-kotlin-annotations
-    ext.csenseAnnotationVersion = "0.0.50"
+    ext.csenseAnnotationVersion = "0.0.60"
 
 
     //versions & naming
-    ext.csenseVersionName = "0.0.59"
+    ext.csenseVersionName = "0.0.60"
     ext.csenseGroupId = "csense.kotlin"
     ext.csenseArtifactId = "csense-kotlin-tests"
 
@@ -56,14 +56,18 @@ kotlin {
     explicitApi = 'strict'
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = '1.8'
+            kotlinOptions.jvmTarget = '11'
         }
         withJava()
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
         }
     }
-    js(BOTH) { //https://kotlinlang.org/docs/reference/whatsnew14.html#new-js-ir-backend
+    iosArm64()
+    iosX64()
+    macosArm64()
+    macosX64()
+    js(IR) { //https://kotlinlang.org/docs/reference/whatsnew14.html#new-js-ir-backend
         browser()
         nodejs()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     //https://github.com/JetBrains/kotlin/releases
     ext.kotlin_version = "1.8.10"
     //https://github.com/csense-oss/csense-kotlin-annotations
-    ext.csenseAnnotationVersion = "0.0.60"
+    ext.csenseAnnotationVersion = "0.0.61"
 
 
     //versions & naming

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ kotlin {
     iosX64()
 
     //- tier 2
-    linuxArm64()
+    //linuxArm64() //cannot be used as of now, due to coroutines not having this (will be fixed in the future)
     watchosSimulatorArm64()
     watchosX64()
     watchosArm32()
@@ -109,10 +109,8 @@ kotlin {
             dependencies {
                 api "org.junit.jupiter:junit-jupiter-api:$junit5Version"
                 api "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-                api "junit:junit:$junit4Version"
                 api "org.junit.vintage:junit-vintage-engine:$junit5Version"
                 api "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
-                api "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,14 +66,35 @@ kotlin {
             useJUnitPlatform()
         }
     }
-    iosArm64()
-    iosX64()
-    macosArm64()
-    macosX64()
-    js(IR) { //https://kotlinlang.org/docs/reference/whatsnew14.html#new-js-ir-backend
+    js(IR) {
         browser()
         nodejs()
     }
+
+    //Native targets, based on https://kotlinlang.org/docs/native-target-support.html
+    //- tier 1
+    linuxX64()
+    macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    //- tier 2
+    linuxArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    iosArm64()
+
+    //- tier 3 (some)
+    mingwX64()
+    //end native targets
+
+
     sourceSets {
         commonMain {
             dependencies {
@@ -100,14 +121,6 @@ kotlin {
                 api "org.jetbrains.kotlin:kotlin-test-js:$kotlin_version"
             }
         }
-        configureEach {
-            languageSettings {
-                languageVersion = "1.8"
-                optIn("kotlin.contracts.ExperimentalContracts")
-                progressiveMode = true
-            }
-
-        }
     }
 }
 
@@ -121,7 +134,15 @@ apply from: "$rootDir/gradle/publish.gradle"
 
 // warnings as errors
 tasks.withType(KotlinCompile).configureEach {
-    kotlinOptions {
-        kotlinOptions.allWarningsAsErrors = true
+    kotlinOptions.allWarningsAsErrors = true
+}
+
+//progressive mode & api version + optIns
+kotlin.sourceSets.configureEach {
+    languageSettings {
+        progressiveMode = true
+        languageVersion = "1.8"
+        optIn("kotlin.contracts.ExperimentalContracts")
     }
 }
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # 0.0.60
-- now available on macos targets & ios targets
+- now available on tier 1 & tier 2 (mostly) targets + mingw
 - targets java 11
 - only ships with junit 5 on jvm.
 - added

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,11 @@
 # 0.0.60
+- now available on macos targets & ios targets
+- targets java 11
 - added
     - assertDispatcher<Default, Main, Unconfined, IO>
     - assertNotByEquals
     - error(s) to when using assertNull / assertNotNull wrongly (eg on a non-nullable value)
-
+  
 - changed
   - assertIs(apply) to accept null, which of cause will fail the test
   - 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.0.60
+- added
+    - assertDispatcher<Default, Main, Unconfined, IO>
+
 # 0.0.59
 
 - using kotlin 1.7.20

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # 0.0.60
 - now available on macos targets & ios targets
 - targets java 11
+- only ships with junit 5 on jvm.
 - added
     - assertDispatcher<Default, Main, Unconfined, IO>
     - assertNotByEquals

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,12 @@
 # 0.0.60
 - added
     - assertDispatcher<Default, Main, Unconfined, IO>
+    - assertNotByEquals
+    - error(s) to when using assertNull / assertNotNull wrongly (eg on a non-nullable value)
 
+- changed
+  - assertIs(apply) to accept null, which of cause will fail the test
+  - 
 # 0.0.59
 
 - using kotlin 1.7.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@
 kotlin.incremental.multiplatform=true
 kotlin.incremental=true
 kotlin.incremental.usePreciseJavaTracking=true
-kotlin.js.compiler=both
 org.gradle.vfs.watch=true
 #enableCompatibilityMetadataVariant is a special mode for libraries published with HMPP that adds an old-style *.kotlin_metadata variant that can be consumed by non-HMPP users. It is only useful for migration period until we enable HMPP by default.
 kotlin.mpp.enableCompatibilityMetadataVariant=false

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,10 +2,10 @@ apply plugin: "maven-publish"
 
 
 afterEvaluate {
-    project.publishing.publications.all {
+    project.publishing.publications.configureEach {
         groupId = group
         // Rename MPP artifacts for backward compatibility
-        def type = it.name
+        final String type = it.name
         switch (type) {
             case 'kotlinMultiplatform':
                 // With Kotlin 1.4 & HMPP, the root module should have no suffix in the ID, but for compatibility with
@@ -61,7 +61,7 @@ publishing {
             final Properties properties = new Properties()
             try {
                 properties.load(project.rootProject.file("local.properties").newDataInputStream())
-            } catch (Exception) {
+            } catch (ignored) {
 
             }
             url 'https://pkgs.dev.azure.com/csense-oss/csense-oss/_packaging/csense-oss/maven/v1'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -14,10 +14,7 @@ afterEvaluate {
                 apply from: "$rootDir/gradle/publish-mpp-root-module-in-platform.gradle"
                 publishPlatformArtifactsInRootModule(publishing.publications["jvm"])
                 break
-            case 'metadata':
-            case 'jvm':
-            case 'js':
-            case 'native':
+            default:
                 it.artifactId = "$project.name-$type"
                 break
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/Coroutines.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 @file:Suppress("unused")
 
 package csense.kotlin.tests.assertions
@@ -8,6 +7,17 @@ import kotlinx.coroutines.test.*
 import kotlin.coroutines.*
 import kotlin.time.*
 
+public fun CoroutineScope.assertDispatcherDefault() {
+    assertDispatcher(Dispatchers.Default)
+}
+
+public fun CoroutineScope.assertDispatcherMain() {
+    assertDispatcher(Dispatchers.Main)
+}
+
+public fun CoroutineScope.assertDispatcherUnconfined() {
+    assertDispatcher(Dispatchers.Unconfined)
+}
 
 public fun CoroutineScope.assertDispatcher(otherDispatcher: CoroutineDispatcher) {
     getCurrentDispatcher().assertAs(otherDispatcher)
@@ -18,7 +28,3 @@ private fun CoroutineScope.getCurrentDispatcher() = coroutineContext.getCurrentD
 private fun CoroutineContext.getCurrentDispatcher(): CoroutineDispatcher =
     this[ContinuationInterceptor] as CoroutineDispatcher
 
-
-public fun TestScope.advanceTimeBy(duration: Duration) {
-    advanceTimeBy(delayTimeMillis = duration.inWholeMilliseconds)
-}

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
@@ -47,14 +47,16 @@ public inline fun <reified T> Any.assertAs(
  * @param message [String] the message to print if the receiver is a different type from [T]
  */
 
-public inline fun <reified T> Any.assertIs(
-    message: String = "expected `$this` of type `${this::class.simpleName}`  to be of type `${T::class}`, but it is not",
+public inline fun <reified T> Any?.assertIs(
+    message: String = "expected `$this` of type `${this.helpers.simpleClassNameOrDash()}`  to be of type `${T::class}`, but it is not",
 ) {
     contract {
         returns() implies (this@assertIs is T)
     }
     assertTrue(this is T, message)
 }
+
+
 
 /**
  * Assert this is the given type
@@ -84,6 +86,13 @@ public fun Any?.assertNotNull(message: String = "") {
     assertNotNull(this, message)
 }
 
+@Suppress("UnusedReceiverParameter", "DeprecatedCallableAddReplaceWith")
+@Deprecated(
+    "Asserting compile time known notnull value to be not null is an error",
+    level = DeprecationLevel.ERROR
+)
+public fun Any.assertNotNull(message: String = ""): Nothing = failTest()
+
 /**
  * Asserts this is null (and if it is null, then kotlin smart casts it to a null variable)
  * @receiver [Any]?
@@ -96,6 +105,13 @@ public fun Any?.assertNull(message: String = "") {
     }
     assertNull(this, message)
 }
+
+@Suppress("UnusedReceiverParameter", "DeprecatedCallableAddReplaceWith")
+@Deprecated(
+    "Asserting compile time known notnull value to be null is an error",
+    level = DeprecationLevel.ERROR
+)
+public fun Any.assertNull(message: String = ""): Nothing = failTest()
 
 /**
  * Asserts this is not null and if not then applies the given [action] on it
@@ -222,6 +238,16 @@ public fun <@kotlin.internal.OnlyInputTypes T> T.assertByEquals(
     val isEqual = this?.equals(expected) == true
     isEqual.assertTrue(
         message = "Expected $this to be equal (via equals) to $expected. ${optMessage ?: ""}"
+    )
+}
+
+public fun <@kotlin.internal.OnlyInputTypes T> T.assertNotByEquals(
+    unexpected: T?,
+    optMessage: String? = null
+) {
+    val isNotEqual = this?.equals(unexpected) != true
+    isNotEqual.assertTrue(
+        message = "Expected $this to be different (via equals) to $unexpected. ${optMessage ?: ""}"
     )
 }
 

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/General.kt
@@ -91,7 +91,7 @@ public fun Any?.assertNotNull(message: String = "") {
     "Asserting compile time known notnull value to be not null is an error",
     level = DeprecationLevel.ERROR
 )
-public fun Any.assertNotNull(message: String = ""): Nothing = failTest()
+public fun Any.assertNotNull(message: String = ""): Nothing = failTest(message)
 
 /**
  * Asserts this is null (and if it is null, then kotlin smart casts it to a null variable)
@@ -111,7 +111,7 @@ public fun Any?.assertNull(message: String = "") {
     "Asserting compile time known notnull value to be null is an error",
     level = DeprecationLevel.ERROR
 )
-public fun Any.assertNull(message: String = ""): Nothing = failTest()
+public fun Any.assertNull(message: String = ""): Nothing = failTest(message)
 
 /**
  * Asserts this is not null and if not then applies the given [action] on it

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/String.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/String.kt
@@ -20,7 +20,7 @@ public fun String.assertContains(
 }
 
 /**
- * Asserts that the this string does not contain the given value.
+ * Asserts that this string does not contain the given value.
  * @receiver [String] the string to assert not containing the given [value]
  * @param value [String] the value that should NOT be in this string
  * @param ignoreCase [Boolean] if true, will ignore the casing, false means case sensitive.
@@ -107,7 +107,7 @@ public fun String.assertContainsInOrder(
     values.forEach {
         val next = indexOf(it, currentIndex, ignoreCase)
         if (next < 0) {
-            val messageWithNewline = message.useIfNotEmptyOrThis(message + "\n\n")
+            val messageWithNewline = message.helpers.useIfNotEmptyOrThis(message + "\n\n")
             failTest(
                 "{$messageWithNewline}Could not find \n\t\"$it\" after index $currentIndex in string \n" +
                         "\"$this\"\n" +
@@ -130,7 +130,7 @@ public fun String.assertStartsWith(
     ignoreCase: Boolean = false,
     message: String = ""
 ) {
-    val messageWithNewline = message.useIfNotEmptyOrThis(message + "\n")
+    val messageWithNewline = message.helpers.useIfNotEmptyOrThis(message + "\n")
     val textOutput = "${messageWithNewline}Could not find \"$prefix\", in  \n" +
             "\"$this\""
     assertTrue(this.startsWith(prefix, ignoreCase = ignoreCase), textOutput)
@@ -148,7 +148,7 @@ public fun String.assertEndsWith(
     ignoreCase: Boolean = false,
     message: String = ""
 ) {
-    val messageWithNewline = message.useIfNotEmptyOrThis(message + "\n")
+    val messageWithNewline = message.helpers.useIfNotEmptyOrThis(message + "\n")
     val textOutput = "${messageWithNewline}Could not find \"$prefix\", in  \n" +
             "\"$this\""
     assertTrue(this.endsWith(prefix, ignoreCase = ignoreCase), textOutput)

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/TestScope.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/TestScope.kt
@@ -1,0 +1,13 @@
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+@file:Suppress("unused")
+
+package csense.kotlin.tests.assertions
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.*
+import kotlin.time.*
+
+
+public fun TestScope.advanceTimeBy(duration: Duration) {
+    advanceTimeBy(delayTimeMillis = duration.inWholeMilliseconds)
+}

--- a/src/commonMain/kotlin/csense/kotlin/tests/assertions/testExtensions.kt
+++ b/src/commonMain/kotlin/csense/kotlin/tests/assertions/testExtensions.kt
@@ -1,15 +1,26 @@
 package csense.kotlin.tests.assertions
 
-//contains extensions for this test module not for user code
+//contains extensions for this test module (stored away in a namespace called "helpers")
+
+public data class TestHelpers<T>(val value: T)
+
+public inline val <T> T.helpers: TestHelpers<T>
+    get() = TestHelpers(this)
+
+public fun <T> TestHelpers<T>?.simpleClassNameOrDash(): String {
+    this ?: return "-"
+    return this::class.simpleName ?: "-"
+}
+
 /**
  * If this is empty, empty is returned, otherwise the given string is
  * @receiver String
  * @param ifNotEmptyString String
  * @return String
  */
-internal fun String.useIfNotEmptyOrThis(ifNotEmptyString: String): String {
-    if (this.isEmpty()) {
-        return this
+public fun TestHelpers<String>.useIfNotEmptyOrThis(ifNotEmptyString: String): String {
+    if (value.isEmpty()) {
+        return value
     }
     return ifNotEmptyString
 }

--- a/src/commonTest/kotlin/csense/kotlin/tests/assertions/GeneralTest.kt
+++ b/src/commonTest/kotlin/csense/kotlin/tests/assertions/GeneralTest.kt
@@ -19,7 +19,7 @@ class GeneralTest {
 
     @Test
     fun anyAssertNotNull() {
-        "".assertNotNull()
+        "".nullable().assertNotNull()
         assertThrows<Throwable> {
             val x: Int? = null
             x.assertNotNull()
@@ -31,7 +31,7 @@ class GeneralTest {
         val x: Int? = null
         x.assertNull()
         assertThrows<Throwable> {
-            "".assertNull()
+            "".nullable().assertNull()
         }
     }
 

--- a/src/jvmMain/kotlin/csense/kotlin/tests/CoroutinesJvm.kt
+++ b/src/jvmMain/kotlin/csense/kotlin/tests/CoroutinesJvm.kt
@@ -1,0 +1,9 @@
+package csense.kotlin.tests
+
+import csense.kotlin.tests.assertions.*
+import kotlinx.coroutines.*
+
+
+public fun CoroutineScope.assertDispatcherIO() {
+    assertDispatcher(Dispatchers.IO)
+}


### PR DESCRIPTION
- now available on tier 1 & tier 2 (mostly) targets + mingw
- targets java 11
- only ships with junit 5 on jvm.
- added
    - assertDispatcher<Default, Main, Unconfined, IO>
    - assertNotByEquals
    - error(s) to when using assertNull / assertNotNull wrongly (eg on a non-nullable value)
  
- changed
  - assertIs(apply) to accept null, which of cause will fail the test
  